### PR TITLE
feat(automation): turn radiadores off outside external window

### DIFF
--- a/automation/radiadores_external.yaml
+++ b/automation/radiadores_external.yaml
@@ -12,63 +12,78 @@
     trigger: state
   - entity_id: light.luz_sofa
     trigger: state
-  conditions:
-  - condition: time
-    after: "17:00:00"
-    before: "22:00:00"
+  conditions: []
   actions:
-  - action: script.radiadores_set_external
-    data:
-      option: external
   - choose:
     - conditions:
-      - condition: state
-        entity_id: input_boolean.at_home
-        state: 'off'
+      - condition: time
+        after: "17:00:00"
+        before: "22:00:00"
       sequence:
-      - action: script.set_radiador
+      - action: script.radiadores_set_external
         data:
-          entity:
-          - climate.radiador_dormitorio
-          - climate.radiador_dario
-          - climate.radiador_estudio
-          - climate.radiador_entrada
-          - climate.radiador_salon
-          target: 18
+          option: external
+      - choose:
+        - conditions:
+          - condition: state
+            entity_id: input_boolean.at_home
+            state: 'off'
+          sequence:
+          - action: script.set_radiador
+            data:
+              entity:
+              - climate.radiador_dormitorio
+              - climate.radiador_dario
+              - climate.radiador_estudio
+              - climate.radiador_entrada
+              - climate.radiador_salon
+              target: 18
+        default:
+        - action: script.set_radiador
+          data:
+            entity: climate.radiador_dormitorio
+            target: "{% set MIN = 13 %} {% set target_temp = states('input_number.radiador_dormitorio_target')\
+              \ | float(21) %}\n{% if is_state('input_boolean.radiador_dormitorio_auto',\
+              \ 'on') %}\n  {{ target_temp if 18 <= now().hour < 20 else MIN }}\n{% else\
+              \ %}\n  {{ target_temp }}\n{% endif %}"
+        - action: script.set_radiador
+          data:
+            entity: climate.radiador_dario
+            target: "{% set MIN = 18 %} {% set target_temp = states('input_number.radiador_dario_target')\
+              \ | float(21) %}\n{% if is_state('input_boolean.radiador_dario_auto', 'on')\
+              \ %}\n  {% set h = now().hour %}\n  {% if is_state('input_boolean.is_holiday','on')\
+              \ %}\n    {{ target_temp if 7 <= h < 19 else MIN }}\n  {% else %}\n    {{\
+              \ target_temp if (7 <= h < 9) or (17 <= h < 20) else MIN }}\n  {% endif\
+              \ %}\n{% else %}\n  {{ target_temp }}\n{% endif %}"
+        - action: script.set_radiador
+          data:
+            entity: climate.radiador_estudio
+            target: "{% set MIN = 19 %} {% set target_temp = states('input_number.radiador_estudio_target')\
+              \ | float(21) %}\n{% if is_state('input_boolean.radiador_estudio_auto',\
+              \ 'on') %}\n  {% if not is_state('input_boolean.is_holiday','on') and (7\
+              \ <= now().hour < 16) %}\n    {{ target_temp }}\n  {% else %}\n    {{ MIN\
+              \ }}\n  {% endif %}\n{% else %}\n  {{ target_temp }}\n{% endif %}"
+        - action: script.set_radiador
+          data:
+            entity:
+            - climate.radiador_entrada
+            - climate.radiador_salon
+            target: "{% set MIN = 18 %} {% set target_temp = states('input_number.radiador_salon_target')\
+              \ | float(21) %}\n{% if is_state('input_boolean.radiador_salon_auto', 'on')\
+              \ %}\n  {{ target_temp if (\n      is_state('light.luz_mouille', 'on') or\n\
+              \      is_state('switch.luz_donut', 'on') or\n      is_state('light.luz_abuelo',\
+              \ 'on') or\n      is_state('light.luz_sofa', 'on') or \n      (7 <= now().hour\
+              \ < 22)\n     ) else MIN }}\n{% else %}\n  {{ target_temp }}\n{% endif\
+              \ %}"
     default:
-    - action: script.set_radiador
-      data:
-        entity: climate.radiador_dormitorio
-        target: "{% set MIN = 13 %} {% set target_temp = states('input_number.radiador_dormitorio_target')\
-          \ | float(21) %}\n{% if is_state('input_boolean.radiador_dormitorio_auto',\
-          \ 'on') %}\n  {{ target_temp if 18 <= now().hour < 20 else MIN }}\n{% else\
-          \ %}\n  {{ target_temp }}\n{% endif %}"
-    - action: script.set_radiador
-      data:
-        entity: climate.radiador_dario
-        target: "{% set MIN = 18 %} {% set target_temp = states('input_number.radiador_dario_target')\
-          \ | float(21) %}\n{% if is_state('input_boolean.radiador_dario_auto', 'on')\
-          \ %}\n  {% set h = now().hour %}\n  {% if is_state('input_boolean.is_holiday','on')\
-          \ %}\n    {{ target_temp if 7 <= h < 19 else MIN }}\n  {% else %}\n    {{\
-          \ target_temp if (7 <= h < 9) or (17 <= h < 20) else MIN }}\n  {% endif\
-          \ %}\n{% else %}\n  {{ target_temp }}\n{% endif %}"
-    - action: script.set_radiador
-      data:
-        entity: climate.radiador_estudio
-        target: "{% set MIN = 19 %} {% set target_temp = states('input_number.radiador_estudio_target')\
-          \ | float(21) %}\n{% if is_state('input_boolean.radiador_estudio_auto',\
-          \ 'on') %}\n  {% if not is_state('input_boolean.is_holiday','on') and (7\
-          \ <= now().hour < 16) %}\n    {{ target_temp }}\n  {% else %}\n    {{ MIN\
-          \ }}\n  {% endif %}\n{% else %}\n  {{ target_temp }}\n{% endif %}"
-    - action: script.set_radiador
-      data:
-        entity:
+    - action: climate.set_hvac_mode
+      target:
+        entity_id:
+        - climate.radiador_dormitorio
+        - climate.radiador_dario
+        - climate.radiador_estudio
         - climate.radiador_entrada
         - climate.radiador_salon
-        target: "{% set MIN = 18 %} {% set target_temp = states('input_number.radiador_salon_target')\
-          \ | float(21) %}\n{% if is_state('input_boolean.radiador_salon_auto', 'on')\
-          \ %}\n  {{ target_temp if (\n      is_state('light.luz_mouille', 'on') or\n\
-          \      is_state('switch.luz_donut', 'on') or\n      is_state('light.luz_abuelo',\
-          \ 'on') or\n      is_state('light.luz_sofa', 'on') or \n      (7 <= now().hour\
-          \ < 22)\n     ) else MIN }}\n{% else %}\n  {{ target_temp }}\n{% endif %}"
+      data:
+        hvac_mode: 'off'
   mode: single


### PR DESCRIPTION
## Context
Actualizar automation/radiadores_external para apagar (hvac_mode off) todos los radiadores fuera del intervalo 17:00-22:00 y mantener la lógica actual dentro de ese intervalo.

## Summary of changes
- Removed the global time condition so the automation always evaluates.
- Wrapped existing external-control behavior in a time-gated choose block for 17:00-22:00.
- Added a default branch that sets hvac_mode to off for all radiator climate entities outside that interval.